### PR TITLE
Fixed issue with package name accidentally being reverted

### DIFF
--- a/openmm-dev/meta.yaml
+++ b/openmm-dev/meta.yaml
@@ -1,6 +1,6 @@
 package:
-  name: openmm
-  version: 6.3
+  name: openmm-dev
+  version: !!str 7.0.0.dev0
 
 source:
   git_url: https://github.com/pandegroup/openmm.git


### PR DESCRIPTION
This should fix the `osx` (and eventually `linux`) platform build issues noted here:
https://github.com/pandegroup/openmm/issues/1079
